### PR TITLE
parse crashes if message dict contain an empty value

### DIFF
--- a/syslog_rfc5424_parser/message.py
+++ b/syslog_rfc5424_parser/message.py
@@ -110,7 +110,12 @@ class SyslogMessage(object):
                 sd.setdefault(item['sd_id'], {})
                 if 'sd_params' in item:
                     for param_pair in item['sd_params']:
-                        sd[item['sd_id']][param_pair['param_name']] = param_pair['param_value']
+                        try:
+                            # empty string values not appeared in the ParseResults
+                            param_value = param_pair['param_value']
+                        except KeyError:
+                            param_value = ""
+                        sd[item['sd_id']][param_pair['param_name']] = param_value
         return cls(severity=severity, facility=facility, version=version, hostname=hostname,
                    timestamp=timestamp, appname=appname, procid=procid, msgid=msgid, msg=msg,
                    sd=sd)


### PR DESCRIPTION
Currently it's crash on the following log line - 
generated by junos MX80 - 
<29>1 2018-05-14T08:23:01.520Z leyal_test4 mgd 13894 UI_CHILD_EXITED [junos@2636.1.1.1.2.57 pid="14374" return-value="5" core-dump-status="" command="/usr/sbin/mustd"]. 

In am not expert in pyparse but it's looks that when the value of a string is an empty-string the  "param-value" is not set and it's cause the process to crash. 
