### PR TITLE
allow embedded newlines in message body

### DIFF
--- a/syslog_rfc5424_parser/message.py
+++ b/syslog_rfc5424_parser/message.py
@@ -75,15 +75,15 @@ class SyslogMessage(object):
     def parse(cls, message_string):
         """Construct a syslog message from a string"""
         try:
-            groups = parser.syslog_message.parseString(message_string)
-        except pyparsing.ParseException:
+            groups, _, end_offset = next(parser.syslog_message.scanString(message_string))
+        except (pyparsing.ParseException, StopIteration):
             raise ParseError('Unable to parse message', message_string)
         header = groups['header']
         structured_data = groups['sd']
-        if 'msg' in groups:
-            msg = groups['msg']
-        else:
-            msg = None
+        msg = message_string[end_offset:] or None
+        if msg:
+            # always starts with a space
+            msg = msg[1:]
         pri = int(header['pri'])
         fac = pri >> 3
         sev = pri & 7

--- a/syslog_rfc5424_parser/parser.py
+++ b/syslog_rfc5424_parser/parser.py
@@ -58,8 +58,7 @@ structured_data = (NilValue | OneOrMore(sd_element)).setResultsName('sd_element'
 
 msg = Combine(restOfLine + lineEnd)
 
-syslog_message = header.setResultsName('header') + SP + structured_data.setResultsName('sd') + \
-    Optional(SP + msg.setResultsName('msg'))
+syslog_message = header.setResultsName('header') + SP + structured_data.setResultsName('sd')
 
 
 __all__ = ['syslog_message', 'structured_data', 'header']

--- a/tests/test_message_parser.py
+++ b/tests/test_message_parser.py
@@ -47,7 +47,7 @@ PARSE_VECTORS = (
     (
         '<85>1 2017-03-02T13:21:15.733598-08:00 vrs-1 polkitd 20481 - -  msg',
         Expected(SyslogSeverity.notice, SyslogFacility.authpriv, 1, '2017-03-02T13:21:15.733598-08:00', 'vrs-1',
-                 'polkitd', 20481, None, 'msg', {})
+                 'polkitd', 20481, None, ' msg', {})
     ),
     # reported in pr 2; empty sd-param body
     (
@@ -61,6 +61,12 @@ PARSE_VECTORS = (
                          'return-value': '5',
                      }
                  })
+    ),
+    # reported in issue #7; multi-line body
+    (
+        '<78>1 2019-01-17T17:39:00Z localhost CROND 9999 - - some message\nwith embedded newlines',
+        Expected(SyslogSeverity.info, SyslogFacility.cron, 1, '2019-01-17T17:39:00Z',
+                 'localhost', 'CROND', 9999, None, 'some message\nwith embedded newlines', {})
     )
 )
 


### PR DESCRIPTION
Fixes #7 

I think it's possibly a bug in PyParsing that `Optional(SP)` never matches anything due to being forcibly non-greedy, but whatever.