### PR TITLE
Update parser.py to resolve DeprecationWarning.

### DIFF
--- a/syslog_rfc5424_parser/parser.py
+++ b/syslog_rfc5424_parser/parser.py
@@ -3,7 +3,7 @@ import collections
 from lark import Lark, Transformer
 
 
-GRAMMAR = '''
+GRAMMAR = r'''
     ?start           : header _SP structured_data [ msg ]
     ?header          : pri version _SP timestamp _SP hostname _SP appname _SP procid _SP msgid
     pri              : "<" /[0-9]{1,3}/ ">"


### PR DESCRIPTION
/vpp/.tox/py36/lib/python3.6/site-packages/syslog_rfc5424_parser/parser.py:39: DeprecationWarning: invalid escape sequence \.
  '''