### PR TITLE
point build status link at travis-ci.com instead of travis-ci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This module implements an [RFC 5424](https://tools.ietf.org/html/rfc5424) IETF Syslog Protocol parser in Python, using the [lark](https://github.com/lark-parser/lark) parser-generator. It should work on Python 2.7 or Python 3.3+.
 
-[![Build Status](https://travis-ci.org/EasyPost/syslog-rfc5424-parser.svg?branch=master)](https://travis-ci.org/EasyPost/syslog-rfc5424-parser)
+[![Build Status](https://travis-ci.com/EasyPost/syslog-rfc5424-parser.svg?branch=master)](https://travis-ci.com/EasyPost/syslog-rfc5424-parser)
 [![PyPI version](https://badge.fury.io/py/syslog-rfc5424-parser.svg)](https://badge.fury.io/py/syslog-rfc5424-parser)
 [![Documentation Status](https://readthedocs.org/projects/syslog-rfc5424-parser/badge/?version=latest)](https://syslog-rfc5424-parser.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
I'm migrating everything to the new infrastructure.